### PR TITLE
Update coinAPI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Somos a maior plataforma de negociação de criptomoedas e ativos alternativos d
 O objetivo deste desafio é entender seus conhecimentos, estilo de programação e como você resolve desafios técnicos.
 
 ### Projeto
-Criar um aplicativo para consultar a [coinapi.io](https://docs.coinapi.io/?shell#list-all-exchanges-get) e trazer as exchanges em forma de lista.
+Criar um aplicativo para consultar a [coinapi.io](https://docs.coinapi.io/market-data/rest-api/metadata/list-all-exchanges) e trazer as exchanges em forma de lista.
 
 ### Credencial da API
 Será necessária uma [API_KEY](https://console.coinapi.io/?link=/apikeys/create) para utilizar a API.


### PR DESCRIPTION
Update coinAPI link to redirect to the correct documentation. The previous link was broken. 